### PR TITLE
Add new v2 GPG key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,6 @@ jobs:
           - almalinux-8
           - almalinux-9
           - amazonlinux-2023
-          - centos-7
-          - centos-stream-8
           - centos-stream-9
           - rockylinux-8
           - rockylinux-9
@@ -39,7 +37,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Install Chef
-        uses: actionshub/chef-install@3.0.0
+        uses: actionshub/chef-install@3.0.1
       - name: Dokken
         uses: actionshub/test-kitchen@3.0.0
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This file is used to list changes made in each version of the yum-elrepo cookboo
 
 ## Unreleased
 
+- Add new v2 GPG key
+
 ## 2.2.10 - *2024-05-03*
 
 ## 2.2.9 - *2024-05-03*

--- a/attributes/elrepo.rb
+++ b/attributes/elrepo.rb
@@ -1,4 +1,4 @@
 default['yum']['elrepo']['mirrorlist'] = "https://elrepo.org/mirrors-elrepo.el#{yum_elrepo_release}"
 default['yum']['elrepo']['description'] = "ELRepo.org Community Enterprise Linux Repository - el#{yum_elrepo_release}"
-default['yum']['elrepo']['gpgkey'] = 'https://elrepo.org/RPM-GPG-KEY-elrepo.org'
+default['yum']['elrepo']['gpgkey'] = 'https://elrepo.org/RPM-GPG-KEY-elrepo.org https://www.elrepo.org/RPM-GPG-KEY-v2-elrepo.org'
 default['yum']['elrepo']['enabled'] = true

--- a/attributes/extras.rb
+++ b/attributes/extras.rb
@@ -1,4 +1,4 @@
 default['yum']['elrepo-extras']['mirrorlist'] = "https://elrepo.org/mirrors-elrepo-extras.el#{yum_elrepo_release}"
 default['yum']['elrepo-extras']['description'] = "ELRepo.org Community Enterprise Linux Extras Repository - el#{yum_elrepo_release}"
-default['yum']['elrepo-extras']['gpgkey'] = 'https://elrepo.org/RPM-GPG-KEY-elrepo.org'
+default['yum']['elrepo-extras']['gpgkey'] = 'https://elrepo.org/RPM-GPG-KEY-elrepo.org https://www.elrepo.org/RPM-GPG-KEY-v2-elrepo.org'
 default['yum']['elrepo-extras']['enabled'] = true

--- a/attributes/kernel.rb
+++ b/attributes/kernel.rb
@@ -1,4 +1,4 @@
 default['yum']['elrepo-kernel']['mirrorlist'] = "https://elrepo.org/mirrors-elrepo-kernel.el#{yum_elrepo_release}"
 default['yum']['elrepo-kernel']['description'] = "ELRepo.org Community Enterprise Linux Kernel Repository - el#{yum_elrepo_release}"
-default['yum']['elrepo-kernel']['gpgkey'] = 'https://elrepo.org/RPM-GPG-KEY-elrepo.org'
+default['yum']['elrepo-kernel']['gpgkey'] = 'https://elrepo.org/RPM-GPG-KEY-elrepo.org https://www.elrepo.org/RPM-GPG-KEY-v2-elrepo.org'
 default['yum']['elrepo-kernel']['enabled'] = true

--- a/attributes/testing.rb
+++ b/attributes/testing.rb
@@ -1,4 +1,4 @@
 default['yum']['elrepo-testing']['mirrorlist'] = "https://elrepo.org/mirrors-elrepo-testing.el#{yum_elrepo_release}"
 default['yum']['elrepo-testing']['description'] = "ELRepo.org Community Enterprise Linux Testing Repository - el#{yum_elrepo_release}"
-default['yum']['elrepo-testing']['gpgkey'] = 'https://elrepo.org/RPM-GPG-KEY-elrepo.org'
+default['yum']['elrepo-testing']['gpgkey'] = 'https://elrepo.org/RPM-GPG-KEY-elrepo.org https://www.elrepo.org/RPM-GPG-KEY-v2-elrepo.org'
 default['yum']['elrepo-testing']['enabled'] = true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,6 +5,6 @@ RSpec.configure do |config|
   config.color = true               # Use color in STDOUT
   config.formatter = :documentation # Use the specified formatter
   config.log_level = :error         # Avoid deprecation notice SPAM
-  config.platform = 'centos'
-  config.version = '7'
+  config.platform = 'almalinux'
+  config.version = '9'
 end

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -32,6 +32,6 @@ end
 ).each do |repo|
   describe ini("/etc/yum.repos.d/#{repo}.repo") do
     its("#{repo}.gpgcheck") { should cmp 1 }
-    its("#{repo}.gpgkey") { should cmp 'https://elrepo.org/RPM-GPG-KEY-elrepo.org' }
+    its("#{repo}.gpgkey") { should cmp 'https://elrepo.org/RPM-GPG-KEY-elrepo.org https://www.elrepo.org/RPM-GPG-KEY-v2-elrepo.org' }
   end
 end


### PR DESCRIPTION
The ELRepo project has started using a new GPG key [1].

[1] https://elrepoproject.blogspot.com/2025/01/the-elrepo-project-has-released-new-rpm.html

Signed-off-by: Lance Albertson <lance@osuosl.org>

# Description

Describe what this change achieves

## Issues Resolved

List any existing issues this PR resolves

## Check List

- [ ] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
